### PR TITLE
マイクラのウインドウの名前がMinecraft Educationに変わっていたので更新しました．

### DIFF
--- a/python/minecraft/Control.py
+++ b/python/minecraft/Control.py
@@ -6,10 +6,11 @@ import pyautogui
 import time
 import sys
 
+game_name = 'Minecraft Education'
 slee_time = 0.01
 try:
     if len(sys.argv) >= 2:
-        mcapp = win32gui.FindWindow(None,'Minecraft: Education Edition')
+        mcapp = win32gui.FindWindow(None,game_name)
         time.sleep(1.00)
         left, top, right, bottom = win32gui.GetWindowRect(mcapp)
         print({left} , {top} , {right} , {bottom} )

--- a/python/minecraft/detectMobs.py
+++ b/python/minecraft/detectMobs.py
@@ -121,12 +121,14 @@ def makeTxt(pos, txtPath):
     f.close()
 
 def main():
+    game_name = 'Minecraft Education'
+
     # 初期化
     init()
     opt = setopt()
 
     # Minecraftのウィンドウ取得
-    winHundle = win32gui.FindWindow(None, "Minecraft: Education Edition")
+    winHundle = win32gui.FindWindow(None, game_name)
 
     # Minecraftのウィンドウサイズを取得
     windowSize = win32gui.GetWindowRect(winHundle)

--- a/python/minecraft/detectZombie2.py
+++ b/python/minecraft/detectZombie2.py
@@ -16,7 +16,7 @@ import random
 
 
 ################################
-game_name = 'Minecraft: Education Edition'
+game_name = 'Minecraft Education'
 sleep_time = 0.05
 ################################
 

--- a/python/minecraft/init.py
+++ b/python/minecraft/init.py
@@ -6,7 +6,7 @@ import win32api
 import pydirectinput
 
 ################################
-game_name = 'Minecraft: Education Edition'
+game_name = 'Minecraft Education'
 sleep_time = 0.05
 ################################
 
@@ -35,4 +35,4 @@ def init():
     time.sleep(sleep_time)
 
 if __name__ == '__main__':
-    init()    
+    init()

--- a/python/minecraft/initCameraPos.py
+++ b/python/minecraft/initCameraPos.py
@@ -6,7 +6,7 @@ import win32api
 import pydirectinput
 
 ################################
-game_name = 'Minecraft: Education Edition'
+game_name = 'Minecraft Education'
 sleep_time = 0.05
 ################################
 


### PR DESCRIPTION
マイクラのゲームタイトルがMinecraft: Education EditionからMinecraft Educationに変わったことが原因で画面を特定できないバグを直しました．