### PR TITLE
ある環境で、SetForegroundWindow関数が正常に働かなくなる不具合を修正した

### DIFF
--- a/python/minecraft/init.py
+++ b/python/minecraft/init.py
@@ -3,6 +3,7 @@ import time
 import win32gui
 import win32con
 import win32api
+import win32com.client
 import pydirectinput
 
 ################################
@@ -12,6 +13,9 @@ sleep_time = 0.05
 
 def init():
     mcapp = win32gui.FindWindow(None,game_name)
+    time.sleep(sleep_time)
+    shell = win32com.client.Dispatch("WScript.Shell")
+    shell.SendKeys('%')
     time.sleep(sleep_time)
     win32gui.SetForegroundWindow(mcapp)         #ウィンドウの指定
     time.sleep(sleep_time)


### PR DESCRIPTION
# 一部の環境でwindowを最善面に設定できない不具合の修正
- 2名ほどSetForegroundWindow関数が動作しない環境を確認した。
SetForegroundWindow関数を呼び出す前にAltキーを仮想的に入力するとで不具合の解消を確認し、実装した。(原因は不明)
参照元 https://stackoverflow.com/questions/56857560/win32gui-setforegroundwindowhandle-not-working-in-loop

- 不具合の解消を確認。また、4名のPCで動作確認した結果、特に変な挙動は見られなかった。
